### PR TITLE
Omit the requirement to specify the type attribute for the text inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,6 @@ Currently we add basic utility-friendly form styles for the following form eleme
 - `select[multiple]`
 - `textarea`
 
-**Note that for text inputs, you must add the `type="text"` attribute for these styles to take effect.** This is a necessary trade-off to avoid relying on the overly greedy `input` selector and unintentionally styling elements we don't have solutions for yet, like `input[type="range"]` for example.
-
 Every element has been normalized/reset in a way that they look pretty great without doing anything to them at all:
 
 ```html

--- a/index.html
+++ b/index.html
@@ -23,6 +23,10 @@
               <input type="text" class="mt-1 block w-full" placeholder="john@example.com" />
             </label>
             <label class="block">
+              <span class="text-gray-700">Input (text) [without `type` attribute]</span>
+              <input class="mt-1 block w-full" placeholder="john@example.com" />
+            </label>
+            <label class="block">
               <span class="text-gray-700">Input (email)</span>
               <input type="email" class="mt-1 block w-full" placeholder="john@example.com" />
             </label>

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ const { colors, spacing, borderWidth, borderRadius, outline } = defaultTheme
 const forms = plugin(function ({ addBase, theme }) {
   addBase({
     [`
+      input:not([type]),
       [type='text'],
       [type='email'],
       [type='url'],


### PR DESCRIPTION
That's not a huge deal to support it. So why not.