### PR TITLE
Add base tailwind as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,10 @@
     "postcss": "^8.1.7",
     "tailwindcss": "^2.0.0-alpha.23"
   },
+  "peerDependencies": {
+    "tailwindcss": "^2.0.0"
+  },
   "dependencies": {
     "mini-svg-data-uri": "^1.2.3"
-  }
+  },
 }


### PR DESCRIPTION
This ensures that `@tailwindcss/forms` and `tailwindcss` are installed on the same level in a monorepo. Using both forms and typography, the latter had no issues because it has the peer dependency.