### PR TITLE
mark tailwindcss as a peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,11 +16,14 @@
   "scripts": {
     "prepublishOnly": "node scripts/build.js"
   },
+  "peerDependencies": {
+    "tailwindcss":">=2.0.0"
+  },
   "devDependencies": {
     "autoprefixer": "^10.0.2",
     "clean-css": "^4.2.1",
     "postcss": "^8.1.7",
-    "tailwindcss": "^2.0.0-alpha.23"
+    "tailwindcss": "^2.0.3"
   },
   "dependencies": {
     "mini-svg-data-uri": "^1.2.3"


### PR DESCRIPTION
Internally we are using tailwindcss/plugin, but we don't mark it as a
peerDependency or a normal dependency in our package.json. This means
that this plugin will fail in a monorepo environment when dependnecies
get hoisted. This is because now there is no link to tailwind itself.

Marking it as a peerDependency should fix this, because now there is a
link. People that already have tailwind installed are good to go. People
that use monorepo's should benefit from this additional information.

Side note: NPM 7 starts installing peerDependencies for us https://github.com/npm/rfcs/blob/latest/implemented/0025-install-peer-deps.md
which is nice, because if we added an `explicit` dependency to Tailwind,
then we would always reference our dependency and not the user's
dependency.

Closes: #31
