### PR TITLE
Register styles in `components` layer when using `class` strategy

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ const [baseFontSize, { lineHeight: baseLineHeight }] = defaultTheme.fontSize.bas
 const { colors, spacing, borderWidth, borderRadius, outline } = defaultTheme
 
 const forms = plugin.withOptions(function (options = { strategy: 'base' }) {
-  return function ({ addBase, theme }) {
+  return function ({ addBase, addComponents, theme }) {
     const strategy = options.strategy
 
     const rules = [
@@ -249,7 +249,10 @@ const forms = plugin.withOptions(function (options = { strategy: 'base' }) {
       },
     ]
 
-    addBase(
+    ({ 
+      'base': (rules) => addBase(rules),
+      'class': (rules) => addComponents(rules)
+    })[strategy](
       rules
         .map((rule) => {
           if (rule[strategy] === null) {


### PR DESCRIPTION
Using the `class` strategy makes it work like a collection of form component styles and shouldn't be in the `base` layer.

Also addresses #64.