### PR TITLE
Fix typo breaking background colors on checkboxes & radio buttons

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -197,7 +197,7 @@ const forms = plugin.withOptions(function (options = { strategy: 'base' }) {
           '.form-checkbox:checked:hover',
           '.form-checkbox:checked:focus',
           '.form-radio:checked:hover',
-          '.form-radio:check:focus',
+          '.form-radio:checked:focus',
         ],
         styles: {
           'border-color': 'transparent',


### PR DESCRIPTION
Totally my fault on this one for the bad previous PR... Apologies.

Just in case anyone has reported this or similar:
This typo _really_ rears it's ugly head when using some postcss optimizations that combine style declarations (cssnano, perhaps?), thus breaking the background colors for checkboxes & radio buttons when using the `class` strategy.

Attempting to merge styles like this:
```
.form-checkbox:checked, .form-radio:checked {
    border-color: transparent;
    background-color: currentColor;
    background-size: 100% 100%;
    background-position: center;
    background-repeat: no-repeat;
}
```
into others like so:
```
.form-checkbox:checked,.form-checkbox:checked:focus,.form-checkbox:checked:hover,.form-checkbox:indeterminate,.form-checkbox:indeterminate:focus,.form-checkbox:indeterminate:hover,.form-radio:check:focus,.form-radio:checked,.form-radio:checked:hover {
    border-color: transparent;
    background-color: currentColor;
}
```
Completely breaking the entire rule.