### PR TITLE
Add default box shadow reset

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -95,7 +95,6 @@ const forms = plugin.withOptions(function (options = { strategy: 'base' }) {
           'background-size': `1.5em 1.5em`,
           'padding-right': spacing[10],
           'color-adjust': `exact`,
-          '--tw-shadow': '0 0 #0000',
         },
       },
       {

--- a/src/index.js
+++ b/src/index.js
@@ -40,6 +40,7 @@ const forms = plugin.withOptions(function (options = { strategy: 'base' }) {
           'padding-left': spacing[3],
           'font-size': baseFontSize,
           'line-height': baseLineHeight,
+          '--tw-shadow': '0 0 #0000',
           '&:focus': {
             outline: outline.none[0],
             'outline-offset': outline.none[1],
@@ -49,7 +50,7 @@ const forms = plugin.withOptions(function (options = { strategy: 'base' }) {
             '--tw-ring-color': theme('colors.blue.600', colors.blue[600]),
             '--tw-ring-offset-shadow': `var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color)`,
             '--tw-ring-shadow': `var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color)`,
-            'box-shadow': `var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000)`,
+            'box-shadow': `var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow)`,
             'border-color': theme('colors.blue.600', colors.blue[600]),
           },
         },
@@ -94,6 +95,7 @@ const forms = plugin.withOptions(function (options = { strategy: 'base' }) {
           'background-size': `1.5em 1.5em`,
           'padding-right': spacing[10],
           'color-adjust': `exact`,
+          '--tw-shadow': '0 0 #0000',
         },
       },
       {
@@ -126,6 +128,7 @@ const forms = plugin.withOptions(function (options = { strategy: 'base' }) {
           'background-color': '#fff',
           'border-color': theme('colors.gray.500', colors.gray[500]),
           'border-width': borderWidth['DEFAULT'],
+          '--tw-shadow': '0 0 #0000',
         },
       },
       {
@@ -154,7 +157,7 @@ const forms = plugin.withOptions(function (options = { strategy: 'base' }) {
           '--tw-ring-color': theme('colors.blue.600', colors.blue[600]),
           '--tw-ring-offset-shadow': `var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color)`,
           '--tw-ring-shadow': `var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color)`,
-          'box-shadow': `var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000)`,
+          'box-shadow': `var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow)`,
         },
       },
       {


### PR DESCRIPTION
This PR adds a reset for the shadow to each input element, this is necessary because we are trying to get rid of the universal selector. 

See: https://github.com/tailwindlabs/tailwindcss/pull/5517
Fixes: https://github.com/tailwindlabs/tailwindcss/issues/5042