### PR TITLE
Pull colors from tailwindcss/colors, not defaultTheme

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "concurrently": "^5.3.0",
     "live-server": "^1.2.1",
     "postcss": "^8.1.7",
-    "tailwindcss": "^2.0.3"
+    "tailwindcss": "insiders"
   },
   "dependencies": {
     "mini-svg-data-uri": "^1.2.3"

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,9 @@
 const svgToDataUri = require('mini-svg-data-uri')
 const plugin = require('tailwindcss/plugin')
 const defaultTheme = require('tailwindcss/defaultTheme')
+const colors = require('tailwindcss/colors')
 const [baseFontSize, { lineHeight: baseLineHeight }] = defaultTheme.fontSize.base
-const { colors, spacing, borderWidth, borderRadius, outline } = defaultTheme
+const { spacing, borderWidth, borderRadius, outline } = defaultTheme
 
 const forms = plugin.withOptions(function (options = { strategy: 'base' }) {
   return function ({ addBase, theme }) {


### PR DESCRIPTION
The color palette is slightly different in the upcoming Tailwind CSS v3 release, and the format of the default config file has changed to define `colors` as a function. This means referencing `defaultTheme.colors` doesn't work the way it did in v2, so this PR updates the forms plugin to pull the default colors directly from `tailwindcss/colors` instead.