### PR TITLE
Use `addComponents` for class strategy

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -252,17 +252,20 @@ const forms = plugin.withOptions(function (options = { strategy: 'base' }) {
       },
     ]
 
-    addBase(
-      rules
-        .map((rule) => {
-          if (rule[strategy] === null) {
-            return null
-          }
+    const strategyRules = rules
+      .map((rule) => {
+        if (rule[strategy] === null) {
+          return null
+        }
 
-          return { [rule[strategy]]: rule.styles }
-        })
-        .filter(Boolean)
-    )
+        return { [rule[strategy]]: rule.styles }
+      })
+      .filter(Boolean)
+
+    ;({
+      'base': addBase,
+      'class': addComponents
+    })[strategy](strategyRules)
   }
 })
 

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ const [baseFontSize, { lineHeight: baseLineHeight }] = defaultTheme.fontSize.bas
 const { spacing, borderWidth, borderRadius } = defaultTheme
 
 const forms = plugin.withOptions(function (options = { strategy: 'base' }) {
-  return function ({ addBase, theme }) {
+  return function ({ addBase, addComponents, theme }) {
     const strategy = options.strategy
 
     const rules = [


### PR DESCRIPTION
Currently we cannot use Tailwind's `base` layer because we are migrating our product from Bootstrap. Due to this problem I noticed that probably `.form-*` classes should not be in the `base` bucket but in the `component` instead when using `strategy: 'class'`.

With this change classes are added in `components` bucket.

PS: I was inspired by #66, but don't know why has been closed.
Closes: #64