### PR TITLE
Fix autoprefixer warning about `color-adjust`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Remove duplicate `outline` property ([#116](https://github.com/tailwindlabs/tailwindcss-forms/pull/116))
+- Fix autoprefixer warning about `color-adjust` ([#115](https://github.com/tailwindlabs/tailwindcss-forms/pull/115))
 
 ## [0.5.0] - 2022-03-02
 

--- a/package.json
+++ b/package.json
@@ -23,11 +23,11 @@
     "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1"
   },
   "devDependencies": {
-    "autoprefixer": "^10.4.2",
+    "autoprefixer": "^10.4.6",
     "concurrently": "^5.3.0",
-    "live-server": "^1.2.1",
-    "postcss": "^8.4.5",
-    "tailwindcss": "^3.0.2"
+    "live-server": "^1.2.2",
+    "postcss": "^8.4.13",
+    "tailwindcss": "^3.0.24"
   },
   "dependencies": {
     "mini-svg-data-uri": "^1.2.3"

--- a/src/index.js
+++ b/src/index.js
@@ -126,7 +126,7 @@ const forms = plugin.withOptions(function (options = { strategy: undefined }) {
           'background-repeat': `no-repeat`,
           'background-size': `1.5em 1.5em`,
           'padding-right': spacing[10],
-          'color-adjust': `exact`,
+          'print-color-adjust': `exact`,
         },
       },
       {
@@ -138,7 +138,7 @@ const forms = plugin.withOptions(function (options = { strategy: undefined }) {
           'background-repeat': 'unset',
           'background-size': 'initial',
           'padding-right': spacing[3],
-          'color-adjust': 'unset',
+          'print-color-adjust': 'unset',
         },
       },
       {
@@ -147,7 +147,7 @@ const forms = plugin.withOptions(function (options = { strategy: undefined }) {
         styles: {
           appearance: 'none',
           padding: '0',
-          'color-adjust': 'exact',
+          'print-color-adjust': 'exact',
           display: 'inline-block',
           'vertical-align': 'middle',
           'background-origin': 'border-box',


### PR DESCRIPTION
Until recently FF only supported the non-standard `color-adjust` property. Now that it supports `print-color-adjust` autoprefixer generates warnings when using the non-standard property.

Fixes https://github.com/tailwindlabs/tailwindcss/issues/8250
Fixes #114