### PR TITLE
Remove duplicate `outline` property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Nothing yet!
+### Fixed
+
+- Remove duplicate `outline` property ([#116](https://github.com/tailwindlabs/tailwindcss-forms/pull/116))
 
 ## [0.5.0] - 2022-03-02
 
@@ -24,7 +26,7 @@ Nothing yet!
 ### Fixed
 
 - Use `addComponents` for class strategy ([#91](https://github.com/tailwindlabs/tailwindcss-forms/pull/91))
-- Fix extra height on Safari date/time inputs  ([#109](https://github.com/tailwindlabs/tailwindcss-forms/pull/109))
+- Fix extra height on Safari date/time inputs ([#109](https://github.com/tailwindlabs/tailwindcss-forms/pull/109))
 
 ## [0.4.0] - 2021-12-09
 

--- a/src/index.js
+++ b/src/index.js
@@ -277,8 +277,10 @@ const forms = plugin.withOptions(function (options = { strategy: undefined }) {
         base: [`[type='file']:focus`],
         class: null,
         styles: {
-          outline: `1px solid ButtonText`,
-          outline: `1px auto -webkit-focus-ring-color`,
+          outline: [
+            `1px solid ButtonText`,
+            `1px auto -webkit-focus-ring-color`
+          ],
         },
       },
     ]


### PR DESCRIPTION
These are meant to be fallback styles — not overwritten declarations.

Fixes #112