### PR TITLE
Add type declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@tailwindcss/forms",
   "version": "0.5.1",
   "main": "src/index.js",
+  "types": "src/index.d.ts",
   "license": "MIT",
   "repository": "https://github.com/tailwindlabs/tailwindcss-forms",
   "publishConfig": {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,4 @@
+import { TailwindPluginWithOptionsFn } from 'tailwindcss/plugin'
+
+declare const plugin: TailwindPluginWithOptionsFn<{ strategy?: 'base' | 'class' }>
+export default plugin


### PR DESCRIPTION
This PR adds the ability to import the package under typescript.
My use case has been importing tailwind configuration directly inside `vite.config.ts` files and as such, I had to manually declare the types for `@tailwindcss/forms`.

Since my package was set to `type: module` I could not use `require` either.


```ts
// vite.config.ts
import autoprefixer from "autoprefixer";
import tailwindcss from "tailwindcss";
import tailwindcssForms from "@tailwindcss/forms";
import { defineConfig } from "vite";

export default defineConfig(() => ({
  css: {
    postcss: {
      plugins: [
        tailwindcss({
          content: ["./index.html", "../../{apps,libs}/**/*.{ts,tsx}"],
          plugins: [tailwindcssForms],
          //plugins: [tailwindcssForms({strategy: 'class'})],
          theme: {},
        }),
        autoprefixer(),
      ],
    },
  },
}));
``` 

The types added include support for the `strategy` option as well. 