### PR TITLE
Add type declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@tailwindcss/forms",
   "version": "0.5.1",
   "main": "src/index.js",
+  "types": "src/index.d.ts",
   "license": "MIT",
   "repository": "https://github.com/tailwindlabs/tailwindcss-forms",
   "publishConfig": {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,4 @@
+import { TailwindPluginWithOptionsFn } from 'tailwindcss/plugin'
+
+declare const plugin: TailwindPluginWithOptionsFn<{ strategy?: 'base' | 'class' }>
+export default plugin

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,4 +1,2 @@
-import { TailwindPluginWithOptionsFn } from 'tailwindcss/plugin'
-
-declare const plugin: TailwindPluginWithOptionsFn<{ strategy?: 'base' | 'class' }>
-export default plugin
+declare function plugin(options?: { strategy?: 'base' | 'class' }): Function
+export = plugin


### PR DESCRIPTION
This PR is a continuation of #117 with a few changes. These changes include:

- Refactored to use a simple function instead. This way it doesn't rely on the `@types/tailwindcss` Definetely Typed repo which could cause issues when we release Tailwind CSS 3.1 with our own types.
- Use `export = plugin` instead of `export default plugin` so that it is compatible with `module.export` which is what most people use.

Closes: #117
 

