### PR TITLE
Readme: Remove -D from install

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A plugin that provides a basic reset for form styles that makes form elements ea
 Install the plugin from npm:
 
 ```sh
-npm install -D @tailwindcss/forms
+npm install @tailwindcss/forms
 ```
 
 Then add the plugin to your `tailwind.config.js` file:


### PR DESCRIPTION
TailwindCSS warns you that you shouldn't install tailwindcss-forms as a dev dependency when trying to add it to your tailwind config.

This simple MR simply removes the `-D` flag from the install command within the readme to not confuse people installing it as a dev dependency by accident.