### PR TITLE
Allow for <input> without `type`

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,6 @@ Currently we add basic utility-friendly form styles for the following form eleme
 - `select[multiple]`
 - `textarea`
 
-**Note that for text inputs, you must add the `type="text"` attribute for these styles to take effect.** This is a necessary trade-off to avoid relying on the overly greedy `input` selector and unintentionally styling elements we don't have solutions for yet, like `input[type="range"]` for example.
-
 Every element has been normalized/reset to a simple visually consistent style that is easy to customize with utilities, even elements like `<select>` or `<input type="checkbox">` that normally need to be reset with `appearance: none` and customized using custom CSS:
 
 ```html

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,7 @@ const forms = plugin.withOptions(function (options = { strategy: undefined }) {
       {
         base: [
           "[type='text']",
+          ":not([type])",
           "[type='email']",
           "[type='url']",
           "[type='password']",

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ const forms = plugin.withOptions(function (options = { strategy: undefined }) {
       {
         base: [
           "[type='text']",
-          "input:not([type])",
+          "input:where(:not([type]))",
           "[type='email']",
           "[type='url']",
           "[type='password']",

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ const forms = plugin.withOptions(function (options = { strategy: undefined }) {
       {
         base: [
           "[type='text']",
-          ":not([type])",
+          "input:not([type])",
           "[type='email']",
           "[type='url']",
           "[type='password']",


### PR DESCRIPTION
Allow for `<input />` elements without the `type` attribute (eg. which defaults to a text input), which [may be required by certain codebases](https://github.com/tailwindlabs/tailwindcss-forms/issues/127#issuecomment-1634153557):

```html
<input /> <!-- same as input with type="text" -->
```

Also removed the note from the readme, which isn't required anymore if my approach works

[Preview](https://tailwindcss-forms-git-fork-karlhorky-patch-1-tailwindlabs.vercel.app/) looks good - allows for overriding via A) utility classes and also B) `input` selector:

![Screenshot 2023-07-13 at 17 07 06](https://github.com/tailwindlabs/tailwindcss-forms/assets/1935696/d3cccd8d-7795-4ec1-81a7-02c630535898)
