### PR TITLE
Fix text alignment on date and time inputs on iOS

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -96,6 +96,16 @@ const forms = plugin.withOptions(function (options = { strategy: undefined }) {
         },
       },
       {
+        // In Safari on iOS date and time inputs are centered instead of left-aligned.
+        // Changing the text alignment on the input itself doesn't work. The only
+        // way to fix is using the `-webkit-date-and-time-value` pseudo element.
+        base: ['::-webkit-date-and-time-value'],
+        class: ['.form-input::-webkit-date-and-time-value'],
+        styles: {
+          'text-align': 'left',
+        },
+      },
+      {
         // In Safari on macOS date time inputs are 4px taller than normal inputs
         // This is because there is extra padding on the datetime-edit and datetime-edit-{part}-field pseudo elements
         // See https://github.com/tailwindlabs/tailwindcss-forms/issues/95


### PR DESCRIPTION
Currently date and time inputs on iOS are centered:

<img width="390" alt="image" src="https://github.com/tailwindlabs/tailwindcss-forms/assets/882133/91152178-5c69-4738-a271-28e4325fe98b">

This PR updates these inputs to be left-aligned so that they are consistent with the rest of the form inputs:

<img width="391" alt="image" src="https://github.com/tailwindlabs/tailwindcss-forms/assets/882133/3a55befa-f1db-4f0d-b58e-4f4257f4f1a7">

## The implementation

Changing the text alignment on the input itself doesn't work on iOS. The only way to fix this is using the `-webkit-date-and-time-value` pseudo element:

```css
input[type="date"]::-webkit-date-and-time-value {
  text-align: left;
}
```

And while this totally works, it does come at the cost of users no longer being able to change the text alignment on date and time inputs using a utility class. However, they already couldn't on iOS, so this still feels like a good change.