### PR TITLE
Fix date time bottom spacing on MacOS Safari

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -107,6 +107,17 @@ const forms = plugin.withOptions(function (options = { strategy: undefined }) {
         },
       },
       {
+        // In Safari on macOS date time inputs that are set to `display: block` have unexpected
+        // extra bottom spacing. This can be corrected by setting the `::-webkit-datetime-edit`
+        // pseudo-element to `display: inline-flex`, instead of the browser default of
+        // `display: inline-block`.
+        base: ['::-webkit-datetime-edit'],
+        class: ['.form-input::-webkit-datetime-edit'],
+        styles: {
+          display: 'inline-flex',
+        },
+      },
+      {
         // In Safari on macOS date time inputs are 4px taller than normal inputs
         // This is because there is extra padding on the datetime-edit and datetime-edit-{part}-field pseudo elements
         // See https://github.com/tailwindlabs/tailwindcss-forms/issues/95


### PR DESCRIPTION
In Safari on macOS date time inputs that are set to `display: block` have unexpected extra bottom spacing.

<img width="481" alt="image" src="https://github.com/tailwindlabs/tailwindcss-forms/assets/882133/a83c04a3-e019-4333-b6ad-516ad75b8b1d">

This can be corrected by setting the `::-webkit-datetime-edit` pseudo-element to `display: inline-flex`, instead of the browser default of `display: inline-block`.

> **Note**
> This issue was previously not noticeable in our playgrounds since they were running in quirks mode due to the lack of doctype in those demos. I've [corrected that](https://github.com/tailwindlabs/tailwindcss-forms/commit/d74d4542a13022af1fc1337b013d18ff5b989d27), and now this issue is visible in the playground (again, only on MacOS Safari): https://tailwindcss-forms.vercel.app