### PR TITLE
Update peer dependency version to include 4.0.0-alpha.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Update peer dependency versions to include Tailwind `4.0.0-alpha.20` with support for this plugin ([#163](https://github.com/tailwindlabs/tailwindcss-forms/pull/163))
 
 ## [0.5.7] - 2023-11-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Update peer dependency versions to include Tailwind `4.0.0-alpha.20` with support for this plugin ([#163](https://github.com/tailwindlabs/tailwindcss-forms/pull/163))
+- Update `tailwindcss` peer dependency to include `4.0.0-alpha.20` which adds support for this plugin ([#163](https://github.com/tailwindlabs/tailwindcss-forms/pull/163))
 
 ## [0.5.7] - 2023-11-10
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build": "tailwindcss -o dist/tailwind.css"
   },
   "peerDependencies": {
-    "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1"
+    "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1 || >= 4.0.0-alpha.20"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.6",


### PR DESCRIPTION
Now that we have support for it, we should make `npm install @tailwindcss/forms` not fail 🙂 

The change was tested by installing it via a tarball. 