### PR TITLE
fix: underline select padding

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,7 +157,7 @@
               <label class="block">
                 <span class="text-gray-700">What type of event is it?</span>
                 <select
-                  class="block w-full mt-0 px-0.5 border-0 border-b-2 border-gray-200 focus:ring-0 focus:border-black"
+                  class="block w-full mt-0 pl-0.5 pr-7 border-0 border-b-2 border-gray-200 focus:ring-0 focus:border-black"
                 >
                   <option>Corporate event</option>
                   <option>Wedding</option>


### PR DESCRIPTION
`<select>` element should have a larger right-padding to accommodate the dropdown arrow.

However, the underline themed `<select>` had a `px-0.5` set, causing long text to show above the arrow.

- ![Underline](https://github.com/user-attachments/assets/58f1e6b3-7fb8-4b23-80d0-f55635b5b511)
- ![Unstyled](https://github.com/user-attachments/assets/f29979d7-ece9-4e58-b6b0-38d96b251182)
- ![Simple](https://github.com/user-attachments/assets/b6494a6c-cdfa-4495-ace3-4f857b4bee23)
- ![Solid](https://github.com/user-attachments/assets/68497aea-d5f1-4442-8280-69ec0fcb1099)


