### PR TITLE
Update peer dependency version to include 4.0.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Support installing with beta versions of Tailwind CSS v4 ([#163](https://github.com/tailwindlabs/tailwindcss-forms/pull/163))
 
 ## [0.5.9] - 2024-09-05
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "format": "prettier . --write"
   },
   "peerDependencies": {
-    "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1 || >= 4.0.0-alpha.20"
+    "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1 || >= 4.0.0-alpha.20 || >= 4.0.0-beta.1"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.6",


### PR DESCRIPTION
Same as https://github.com/tailwindlabs/tailwindcss-typography/pull/163 but for beta releases.