### PR TITLE
Turn off if preflight is off

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -355,7 +355,7 @@ const forms = plugin.withOptions(function (options = { strategy: undefined }) {
         })
         .filter(Boolean)
 
-    if (config?..corePlugins?.preflight === false) {
+    if (config?.corePlugins?.preflight === false) {
       return
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ function resolveColor(color, opacityVariableName) {
 }
 
 const forms = plugin.withOptions(function (options = { strategy: undefined }) {
-  return function ({ addBase, addComponents, theme }) {
+  return function ({ addBase, addComponents, theme, config }) {
     function resolveChevronColor(color, fallback) {
       let resolved = theme(color)
 
@@ -354,6 +354,10 @@ const forms = plugin.withOptions(function (options = { strategy: undefined }) {
           return { [rule[strategy]]: rule.styles }
         })
         .filter(Boolean)
+
+    if (config?..corePlugins?.preflight === false) {
+      return
+    }
 
     if (strategy.includes('base')) {
       addBase(getStrategyRules('base'))


### PR DESCRIPTION
I do understand that this plugin is meant to be used only in thus cases where reset is needed. But I do believe that plugin should respect the core settings of the tailwind. https://tailwindcss.com/docs/preflight#disabling-preflight

This PR is not tested