### PR TITLE
Allow released Tailwind 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "format": "prettier . --write"
   },
   "peerDependencies": {
-    "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1 || >= 4.0.0-alpha.20 || >= 4.0.0-beta.1"
+    "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1 || >= 4.0.0-alpha.20 || >= 4.0.0-beta.1 || >= 4.0.0"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.6",


### PR DESCRIPTION
Summary:
Tailwind 4 is out of beta accept that as a peer dependency

Test Plan:
CI