### PR TITLE
docs: clarify checkbox checked background colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,11 @@ Every element has been normalized/reset to a simple visually consistent style th
   <!-- ... -->
 </select>
 
-<!-- Or change a checkbox color using text color utilities: -->
-<input type="checkbox" class="rounded text-pink-500" />
+<!-- Or give a checked checkbox its own background color: -->
+<input type="checkbox" class="rounded checked:bg-pink-500" />
 ```
+
+If you give checkboxes or radios an unchecked background with `bg-*`, use `checked:bg-*` for the checked color. These controls use custom appearance styles, so native `accent-*` utilities do not control the rendered checked background.
 
 More customization examples and best practices coming soon.
 
@@ -84,7 +86,7 @@ In addition to the global styles, we also generate a set of corresponding classe
   <!-- ... -->
 </select>
 
-<input type="checkbox" class="form-checkbox rounded text-pink-500" />
+<input type="checkbox" class="form-checkbox rounded checked:bg-pink-500" />
 ```
 
 Here is a complete table of the provided `form-*` classes for reference:


### PR DESCRIPTION
This updates the checkbox/radio examples to use `checked:bg-*` when showing checked-state colors, and adds a short note for the `bg-*` + checked state case.

The current examples show `text-*` for checkbox color. With the custom appearance styles in this plugin, native `accent-*` utilities do not control the rendered checked background, and in Tailwind CSS v4 an unchecked `bg-*` can make that especially confusing. `checked:bg-*` works for the checked background in both v3 and v4.

Checked:
- `npm test`
- `npm run build`
- Tailwind CSS v3.4.13 fixture build
- Tailwind CSS v4.3.0 fixture build
- Browser computed-style check on the v3/v4 fixtures through `http://127.0.0.1:8765`

Related to #184.